### PR TITLE
Ijr/kill intermediate steps

### DIFF
--- a/markdownEditor/app/controllers/notes_controller.rb
+++ b/markdownEditor/app/controllers/notes_controller.rb
@@ -27,8 +27,11 @@ class NotesController < ApplicationController
     @note = Note.new(note_params)
 
     respond_to do |format|
+
       if @note.save
-        format.html { redirect_to @note, notice: 'Note was successfully created.' }
+          format.html { render :edit}
+          flash[:notice] = "Note successfully created"
+#        format.html { redirect_to @note, notice: 'Note was successfully created.' }
         format.json { render :show, status: :created, location: @note }
       else
         format.html { render :new }

--- a/markdownEditor/app/controllers/notes_controller.rb
+++ b/markdownEditor/app/controllers/notes_controller.rb
@@ -29,9 +29,9 @@ class NotesController < ApplicationController
     respond_to do |format|
 
       if @note.save
-          format.html { render :edit}
-          flash[:notice] = "Note successfully created"
-#        format.html { redirect_to @note, notice: 'Note was successfully created.' }
+        format.html { render :edit}
+        flash[:notice] = "Note successfully created"
+        format.html { redirect_to @note, notice: 'Note was successfully created.' }
         format.json { render :show, status: :created, location: @note }
       else
         format.html { render :new }

--- a/markdownEditor/app/controllers/notes_controller.rb
+++ b/markdownEditor/app/controllers/notes_controller.rb
@@ -45,8 +45,9 @@ class NotesController < ApplicationController
   def update
     respond_to do |format|
       if @note.update(note_params)
-        format.html { redirect_to @note, notice: 'Note was successfully updated.' }
-        format.json { render :show, status: :ok, location: @note }
+          format.html { render :edit}
+          flash[:notice] = "Note successfully updated"
+          format.json { render :show, status: :ok, location: @note }
       else
         format.html { render :edit }
         format.json { render json: @note.errors, status: :unprocessable_entity }

--- a/markdownEditor/app/views/layouts/application.html.erb
+++ b/markdownEditor/app/views/layouts/application.html.erb
@@ -10,9 +10,10 @@
   <nav>
     <%=link_to 'home', controller: 'home', action: 'textEditor' %>
     <%=link_to 'notes', controller: 'notes', action: 'index' %>
+     
      <% if flash[:notice] %>
-    <p class="flash-notice"><%= flash[:notice] %></p>
-  <% end %>
+   		<p id="notice"><%= notice %></p>
+   	 <% end %>
 
   </nav>
 

--- a/markdownEditor/app/views/layouts/application.html.erb
+++ b/markdownEditor/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
   <nav>
     <%=link_to 'home', controller: 'home', action: 'textEditor' %>
     <%=link_to 'notes', controller: 'notes', action: 'index' %>
+     <% if flash[:notice] %>
+    <p class="flash-notice"><%= flash[:notice] %></p>
+  <% end %>
 
   </nav>
 

--- a/markdownEditor/app/views/notes/index.html.erb
+++ b/markdownEditor/app/views/notes/index.html.erb
@@ -1,4 +1,3 @@
-<p id="notice"><%= notice %></p>
 
 <h1>Listing Notes</h1>
 

--- a/markdownEditor/app/views/notes/index.html.erb
+++ b/markdownEditor/app/views/notes/index.html.erb
@@ -19,7 +19,6 @@
         <td><%= note.tag %></td>
         <td><%= note.created_at.to_formatted_s(:long_ordinal) %></td>
 				<td><%= time_ago_in_words(note.updated_at) %> ago</td>
-        <td><%= link_to 'Show', note %></td>
         <td><%= link_to 'Edit', edit_note_path(note) %></td>
         <td><%= link_to 'Destroy', note, method: :delete, data: { confirm: 'Are
          you sure?' } %></td>


### PR DESCRIPTION
This branch deletes the link to show from dashboard and gets rid of intermediate steps when saving or updating and returns the user to the edit page so the user can continue editing after they save their note. Also displays notice on edit page when a note was successfully saved. 
